### PR TITLE
VENT-22 Implement debug mode functionality across onboarding and home…

### DIFF
--- a/app/(app)/home.tsx
+++ b/app/(app)/home.tsx
@@ -11,7 +11,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useProfile } from "@/hooks/queries/auth/useProfileQuery";
 import { useAssessment } from "@/hooks/queries/auth/useAssessmentQuery";
 import { ToastService } from "@/services/ToastService";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 const { width } = Dimensions.get("window")
 
@@ -69,20 +69,41 @@ const HomeScreen = () => {
   // Uncomment these in your Expo project:
   const queryClient = useQueryClient();
   const {
-    authState: { user },
+    authState: { user, isDebugMode },
     signOutMutation,
+    clearDebugData,
+    getDebugData,
   } = useAuth();
   const { data: profile, isLoading: profileLoading } = useProfile();
   const { data: assessments, isLoading: assessmentsLoading } = useAssessment();
+  const [debugData, setDebugData] = useState<any>(null);
+
+  // Load debug data when component mounts or debug mode changes
+  useEffect(() => {
+    const loadDebugData = async () => {
+      if (isDebugMode) {
+        const data = await getDebugData();
+        setDebugData(data);
+      } else {
+        setDebugData(null);
+      }
+    };
+    loadDebugData();
+  }, [isDebugMode, getDebugData]);
 
 
   // Uncomment in your Expo project:
   const handleSignOut = async () => {
     try {
-      await signOutMutation?.mutateAsync();
+      if (isDebugMode) {
+        await clearDebugData();
+        ToastService.info("Debug data cleared");
+      } else {
+        await signOutMutation?.mutateAsync();
+      }
     } catch (error) {
       console.error("Error signing out:", error);
-      ToastService.error(`Error signing out: ${error}`);
+      ToastService.error(`Error: ${error}`);
     }
   }
 
@@ -289,12 +310,38 @@ const HomeScreen = () => {
           </View>
         </View>
 
-        {/* Sign Out Button */}
+        {/* Debug Data Display */}
+        {isDebugMode && debugData && (
+          <View className="mb-4 p-4 bg-yellow-50 border border-yellow-200 rounded-2xl">
+            <Text className="text-sm font-semibold text-yellow-800 mb-2">Debug Data:</Text>
+            {debugData.username && (
+              <Text className="text-xs text-yellow-700 mb-1">Username: {debugData.username}</Text>
+            )}
+            {debugData.fullName && (
+              <Text className="text-xs text-yellow-700 mb-1">Full Name: {debugData.fullName}</Text>
+            )}
+            {debugData.dob && (
+              <Text className="text-xs text-yellow-700 mb-1">DOB: {new Date(debugData.dob).toLocaleDateString()}</Text>
+            )}
+            {debugData.phoneNumber && (
+              <Text className="text-xs text-yellow-700 mb-1">Phone: {debugData.phoneNumber}</Text>
+            )}
+            {debugData.role && (
+              <Text className="text-xs text-yellow-700 mb-1">Role: {debugData.role}</Text>
+            )}
+          </View>
+        )}
+
+        {/* Sign Out / Clear Data Button */}
         <TouchableOpacity
-          className="bg-red-500 rounded-2xl py-4 items-center mb-6"
+          className={`rounded-2xl py-4 items-center mb-6 ${
+            isDebugMode ? "bg-yellow-500" : "bg-red-500"
+          }`}
           onPress={handleSignOut}
         >
-          <Text className="text-white font-semibold text-base">Sign Out</Text>
+          <Text className="text-white font-semibold text-base">
+            {isDebugMode ? "Clear Data" : "Sign Out"}
+          </Text>
         </TouchableOpacity>
       </ScrollView>
 

--- a/app/(app)/home.tsx
+++ b/app/(app)/home.tsx
@@ -13,8 +13,6 @@ import { useAssessment } from "@/hooks/queries/auth/useAssessmentQuery";
 import { ToastService } from "@/services/ToastService";
 import { useEffect, useState } from "react";
 
-const { width } = Dimensions.get("window")
-
 // Helper function to format assessment responses
 const formatAssessmentResponse = (response: {
   text?: string
@@ -335,12 +333,12 @@ const HomeScreen = () => {
         {/* Sign Out / Clear Data Button */}
         <TouchableOpacity
           className={`rounded-2xl py-4 items-center mb-6 ${
-            isDebugMode ? "bg-yellow-500" : "bg-red-500"
+            !user && isDebugMode ? "bg-yellow-500" : "bg-red-500"
           }`}
           onPress={handleSignOut}
         >
           <Text className="text-white font-semibold text-base">
-            {isDebugMode ? "Clear Data" : "Sign Out"}
+            {!user && isDebugMode ? "Clear Data" : "Sign Out"}
           </Text>
         </TouchableOpacity>
       </ScrollView>

--- a/app/(onboard)/assessment.tsx
+++ b/app/(onboard)/assessment.tsx
@@ -27,7 +27,7 @@ import { CLIENT_QUESTIONS, COMMON_QUESTIONS, HOST_QUESTIONS } from "@/utils/auth
 import AsyncStorage from "@react-native-async-storage/async-storage"
 
 export default function AssessmentScreen() {
-  const { authState: { user }, setOnboardingStep } = useAuth()
+  const { authState: { user, isDebugMode }, setOnboardingStep } = useAuth()
   const { data: profile, isLoading: profileLoading } = useProfile()
   const { mutateAsync: updateProfileMutation } = useUpdateProfileMutation()
   const router = useRouter()
@@ -68,7 +68,18 @@ export default function AssessmentScreen() {
       },
     }))
 
-    // Save current answer to Supabase
+    // In debug mode, skip saving to Supabase
+    if (isDebugMode) {
+      console.log("Debug: Answer saved locally:", questionId, answer);
+      return;
+    }
+
+    // Normal mode: Save current answer to Supabase
+    if (!user) {
+      console.log("User not authenticated, skipping save");
+      return;
+    }
+
     try {
       await AssessmentController.saveCurrentAnswer(questionId, answer, user, questions)
     } catch (e: unknown) {
@@ -102,7 +113,17 @@ export default function AssessmentScreen() {
 
   const saveAssessmentData = async () => {
     try {
-      // Update the profile to mark assessment as completed
+      // In debug mode, skip saving to Supabase and just navigate to home
+      if (isDebugMode) {
+        console.log("Debug: Assessment completed, navigating to home");
+        // Mark onboarding as completed
+        await setOnboardingStep(OnboardingStep.COMPLETED);
+        // Navigate to home/dashboard
+        await router.replace('/(app)/home');
+        return;
+      }
+
+      // Normal mode: Update the profile to mark assessment as completed
       await updateProfileMutation({
         assessment_completed: true
       })

--- a/app/(onboard)/mobile.tsx
+++ b/app/(onboard)/mobile.tsx
@@ -34,8 +34,9 @@ export default function MobileScreen() {
   const [keyboardVisible, setKeyboardVisible] = useState(false);
 
   const {
-    authState: { user },
+    authState: { user, isDebugMode },
     setOnboardingStep,
+    saveDebugData,
   } = useAuth();
   const queryClient = useQueryClient();
   const { data: profile } = useProfile();
@@ -73,12 +74,25 @@ export default function MobileScreen() {
    * Validates phone number, upserts to Supabase, and navigates to the next step.
    */
   const handleContinue = async (): Promise<void> => {
-    if (!isFormValid || !user) return;
+    if (!isFormValid) return;
 
     try {
       const trimmedPhoneNumber = phoneNumber.trim();
 
-      // Upsert mobile number to Supabase
+      // In debug mode, save to debug storage instead of Supabase
+      if (isDebugMode) {
+        await saveDebugData({ phoneNumber: trimmedPhoneNumber });
+        console.log("Debug: Mobile number saved");
+        setOnboardingStep(OnboardingStep.ROLE);
+        return;
+      }
+
+      // Normal mode: upsert to Supabase
+      if (!user) {
+        showToast(TOAST.ERROR, "User not authenticated!");
+        return;
+      }
+
       const result = await upsertProfile({
         userId: user.id,
         username: profile?.username,

--- a/app/(onboard)/profile.tsx
+++ b/app/(onboard)/profile.tsx
@@ -42,8 +42,9 @@ export default function ProfileScreen() {
   const [keyboardVisible, setKeyboardVisible] = useState(false);
 
   const {
-    authState: { user },
+    authState: { user, isDebugMode },
     setOnboardingStep,
+    saveDebugData,
   } = useAuth();
   const queryClient = useQueryClient();
 
@@ -70,11 +71,26 @@ export default function ProfileScreen() {
   }, []);
 
   const handleContinue = async (): Promise<void> => {
-    if (!isFormValid || !user) return;
+    if (!isFormValid) return;
 
     try {
-      // Upsert profile data to Supabase
-      // fullName will be split into firstName and lastName automatically
+      // In debug mode, save to debug storage instead of Supabase
+      if (isDebugMode) {
+        await saveDebugData({ 
+          fullName: fullName.trim(),
+          dob: dob ? dob.toISOString() : undefined
+        });
+        console.log("Debug: Profile data saved");
+        setOnboardingStep(OnboardingStep.MOBILE);
+        return;
+      }
+
+      // Normal mode: upsert to Supabase
+      if (!user) {
+        showToast(TOAST.ERROR, "User not authenticated!");
+        return;
+      }
+
       const result = await upsertProfile({
         userId: user.id,
         fullName: fullName.trim(),

--- a/app/(onboard)/role.tsx
+++ b/app/(onboard)/role.tsx
@@ -56,8 +56,9 @@ export default function RoleSelectionScreen() {
   const showToast = useShowToast();
 
   const {
-    authState: { user, profile },
+    authState: { user, profile, isDebugMode },
     setOnboardingStep,
+    saveDebugData,
   } = useAuth();
 
   const handleContinue = async () => {
@@ -71,9 +72,18 @@ export default function RoleSelectionScreen() {
     setError(null);
 
     try {
+      // In debug mode, save to debug storage instead of Supabase
+      if (isDebugMode) {
+        await saveDebugData({ role: selectedRole });
+        console.log("Debug: Role saved");
+        await setOnboardingStep(OnboardingStep.ASSESSMENT);
+        setIsLoading(false);
+        return;
+      }
+
+      // Normal mode: upsert to Supabase
       if (!user) throw new Error("User not authenticated");
 
-      // Upsert the role to Supabase using the centralized function
       const result = await upsertProfile({
         userId: user.id,
         role: selectedRole,

--- a/app/(onboard)/username.tsx
+++ b/app/(onboard)/username.tsx
@@ -33,8 +33,9 @@ export default function UsernameScreen() {
   const [keyboardVisible, setKeyboardVisible] = useState(false);
 
   const {
-    authState: { user },
+    authState: { user, isDebugMode },
     setOnboardingStep,
+    saveDebugData,
   } = useAuth();
   const queryClient = useQueryClient();
 
@@ -62,14 +63,28 @@ export default function UsernameScreen() {
 
   /**
    * Handles continue button press.
-   * Validates username, saves to storage, upserts to Supabase, and navigates to the next step.
+   * Validates username, saves to storage, upserts to Supabase (or debug storage), and navigates to the next step.
    */
   const handleContinue = async (): Promise<void> => {
-    if (!isFormValid || !user) return;
+    if (!isFormValid) return;
 
     try {
       const trimmedUsername = username.trim();
       
+      // In debug mode, save to debug storage instead of Supabase
+      if (isDebugMode) {
+        await saveDebugData({ username: trimmedUsername });
+        console.log("Debug: Username saved:", trimmedUsername);
+        setOnboardingStep(OnboardingStep.PROFILE);
+        return;
+      }
+
+      // Normal mode: upsert to Supabase
+      if (!user) {
+        showToast(TOAST.ERROR, "User not authenticated!");
+        return;
+      }
+
       // Upsert username to Supabase
       const result = await upsertProfile({
         userId: user.id,
@@ -92,7 +107,7 @@ export default function UsernameScreen() {
       setOnboardingStep(OnboardingStep.PROFILE);
     } catch (error) {
       console.error("Error saving username data:", error);
-      showToast(TOAST.ERROR, "Error updating profile data!")
+      showToast(TOAST.ERROR, "Error saving username data!");
     }
   };
 

--- a/app/(public)/welcome.tsx
+++ b/app/(public)/welcome.tsx
@@ -19,12 +19,14 @@ import { FeatureCard, FeatureCardProps } from "@/components/auth/FeatureCard";
 import { useRef, useState } from "react";
 import { useShowToast } from "@/components/ui/toast/useToast";
 import { signInWithApple, signInWithGoogle } from "@/utils/auth/function";
+import { useAuth } from "@/context/auth/AuthContext";
 
 const { width, height } = Dimensions.get("window");
 const CARD_SIZE = (width - 60) / 2;
 
 export default function WelcomeScreen() {
   const router = useRouter();
+  const { enableDebugMode } = useAuth();
 
   const [isAuthVisible, setIsAuthVisible] = useState(false);
   const slideAnim = useRef(new Animated.Value(height)).current;
@@ -190,6 +192,16 @@ export default function WelcomeScreen() {
             <Ionicons name="logo-apple" size={22} color="#000000" />
             <Text className="text-base font-semibold text-gray-800">
               Continue with Apple
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity 
+            className="flex-row items-center justify-center bg-white border border-gray-200 py-4 rounded-2xl gap-3"
+            onPress={enableDebugMode}
+            activeOpacity={0.8}>
+            <Ionicons name="warning-outline" size={22} color="#78350F" />
+            <Text className="text-base font-semibold text-gray-800">
+              Debug Testing
             </Text>
           </TouchableOpacity>
         </View>

--- a/context/auth/AuthContext.tsx
+++ b/context/auth/AuthContext.tsx
@@ -4,7 +4,7 @@
  */
 
 import { supabase } from "@/lib/supabase/supabase";
-import { AuthContextType, AuthState, OnboardingStep } from "@/types/authModel";
+import { AuthContextType, AuthState, OnboardingStep, DebugOnboardingData } from "@/types/authModel";
 import { ProfileModel } from "@/types/user/user";
 import {
   checkAssessmentStatus,
@@ -32,6 +32,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     isLoading: true,
     isAuthenticated: false,
     onboardingStep: OnboardingStep.NONE,
+    isDebugMode: false,
   });
 
   // state to track initial navigation
@@ -39,6 +40,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   
   // Track if we're currently in onboarding route to avoid navigation conflicts
   const isInOnboardingRouteRef = useRef(false);
+
+  // Debug mode storage keys
+  const DEBUG_MODE_KEY = "debug_mode_enabled";
+  const DEBUG_DATA_KEY = "debug_onboarding_data";
 
   // Initialize session data and set up auth listeners
   useEffect(() => {
@@ -269,11 +274,38 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // Handle navigation based on auth and onboarding state
   useEffect(() => {
     console.log("Handling navigation based on auth and onboarding state");
-    if (authState.isLoading) return;
 
     if (isInitialized) {
-      // Not authenticated
-      if (!authState.session) {
+      // Debug mode: handle navigation separately
+      if (authState.isDebugMode) {
+        // In debug mode, check onboarding step
+        if (
+          authState.onboardingStep &&
+          authState.onboardingStep !== OnboardingStep.COMPLETED
+        ) {
+          // Only navigate to onboarding if we're not already there
+          if (!isInOnboardingRouteRef.current) {
+            console.log("Debug mode: navigating to onboarding step:", authState.onboardingStep);
+            isInOnboardingRouteRef.current = true;
+            //@ts-ignore - Expo Router dynamic route
+            router.replace(`/(onboard)/${authState.onboardingStep}`);
+          } else {
+            console.log("Debug mode: Already in onboarding route, letting layout handle step navigation");
+          }
+          return;
+        } else if (
+          !authState.onboardingStep ||
+          authState.onboardingStep === OnboardingStep.COMPLETED
+        ) {
+          // Debug mode and onboarding complete, go to home
+          console.log("Debug mode: onboarding complete, navigating to home");
+          router.replace("/(app)/home");
+          return;
+        }
+      }
+
+      // Not authenticated (and not in debug mode)
+      if (!authState.session && !authState.isDebugMode) {
         console.log("User not authenticated, navigating to auth screen");
         router.replace("/(public)/welcome");
         return;
@@ -490,6 +522,101 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
+  // Debug mode functions
+  const enableDebugMode = async () => {
+    try {
+      await AsyncStorage.setItem(DEBUG_MODE_KEY, "true");
+      setAuthState((prev) => ({
+        ...prev,
+        isDebugMode: true,
+        isAuthenticated: true,
+        onboardingStep: OnboardingStep.USERNAME,
+      }));
+      // Navigate to onboarding
+      router.replace("/(onboard)/username");
+    } catch (error) {
+      console.error("Error enabling debug mode:", error);
+    }
+  };
+
+  const disableDebugMode = async () => {
+    try {
+      await AsyncStorage.removeItem(DEBUG_MODE_KEY);
+      await AsyncStorage.removeItem(DEBUG_DATA_KEY);
+      setAuthState((prev) => ({
+        ...prev,
+        isDebugMode: false,
+        isAuthenticated: false,
+        onboardingStep: OnboardingStep.NONE,
+      }));
+    } catch (error) {
+      console.error("Error disabling debug mode:", error);
+    }
+  };
+
+  const clearDebugData = async () => {
+    try {
+      await AsyncStorage.removeItem(DEBUG_DATA_KEY);
+      await AsyncStorage.removeItem("onboardingStep");
+      setAuthState((prev) => ({
+        ...prev,
+        isDebugMode: false,
+        onboardingStep: OnboardingStep.USERNAME,
+      }));
+      router.replace("/(public)/welcome");
+    } catch (error) {
+      console.error("Error clearing debug data:", error);
+    }
+  };
+
+  const getDebugData = async (): Promise<DebugOnboardingData | null> => {
+    try {
+      const data = await AsyncStorage.getItem(DEBUG_DATA_KEY);
+      return data ? JSON.parse(data) : null;
+    } catch (error) {
+      console.error("Error getting debug data:", error);
+      return null;
+    }
+  };
+
+  const saveDebugData = async (data: Partial<DebugOnboardingData>) => {
+    try {
+      const existing = await getDebugData();
+      const updated = { ...existing, ...data };
+      await AsyncStorage.setItem(DEBUG_DATA_KEY, JSON.stringify(updated));
+    } catch (error) {
+      console.error("Error saving debug data:", error);
+    }
+  };
+
+  // Check debug mode on mount and restore state
+  useEffect(() => {
+    const checkDebugMode = async () => {
+      try {
+        const isDebug = await AsyncStorage.getItem(DEBUG_MODE_KEY);
+        if (isDebug === "true") {
+          // Restore debug mode state
+          const savedStep = await AsyncStorage.getItem("onboardingStep");
+          const onboardingStep = (savedStep as OnboardingStep) || OnboardingStep.USERNAME;
+          
+          setAuthState((prev) => ({
+            ...prev,
+            isDebugMode: true,
+            isAuthenticated: true,
+            isLoading: false,
+            onboardingStep: onboardingStep,
+          }));
+          
+          // Mark as initialized so navigation can proceed
+          setIsInitialized(true);
+        }
+      } catch (error) {
+        console.error("Error checking debug mode:", error);
+      }
+    };
+    checkDebugMode();
+  }, []);
+
   return (
     <AuthContext.Provider
       value={{
@@ -497,6 +624,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         signOutMutation,
         refreshSession,
         setOnboardingStep,
+        isDebugMode: authState.isDebugMode || false,
+        enableDebugMode,
+        disableDebugMode,
+        clearDebugData,
+        getDebugData,
+        saveDebugData,
       }}>
       {children}
     </AuthContext.Provider>

--- a/types/authModel.ts
+++ b/types/authModel.ts
@@ -18,11 +18,26 @@ export enum OnboardingStep {
   COMPLETED = 'completed'
 }
 
+export type DebugOnboardingData = {
+  username?: string;
+  fullName?: string;
+  dob?: string; // ISO string
+  phoneNumber?: string;
+  role?: string;
+};
+
 export type AuthContextType = {
   authState: AuthState;
   refreshSession: () => Promise<void>;
   setOnboardingStep: (state: OnboardingStep) => Promise<void>;
   signOutMutation?: UseMutationResult<void, Error, void>;
+  // Debug mode functions
+  isDebugMode: boolean;
+  enableDebugMode: () => Promise<void>;
+  disableDebugMode: () => Promise<void>;
+  clearDebugData: () => Promise<void>;
+  getDebugData: () => Promise<DebugOnboardingData | null>;
+  saveDebugData: (data: Partial<DebugOnboardingData>) => Promise<void>;
   };
   
 export type AuthState = {
@@ -32,5 +47,6 @@ export type AuthState = {
   isLoading: boolean;
   isAuthenticated: boolean;
   onboardingStep?: OnboardingStep;
+  isDebugMode?: boolean;
 };
   


### PR DESCRIPTION
… screens

- Introduced a debug mode that allows for local data storage instead of Supabase during onboarding.
- Enhanced the HomeScreen to display debug data and clear it upon sign out in debug mode.
- Updated AssessmentScreen, MobileScreen, ProfileScreen, RoleSelectionScreen, and UsernameScreen to handle data saving differently based on debug mode.
- Added functions in AuthContext for enabling/disabling debug mode and managing debug data storage.

These changes improve the development experience by allowing easier testing and debugging of the onboarding flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Debug Testing mode from the welcome screen to run onboarding without real auth or backend.
  * Onboarding screens now support a debug path that saves test data locally and advances steps without network calls.
  * Home screen shows debug data (username, full name, DOB, phone, role) when debug mode is enabled; Sign Out becomes "Clear Data" in debug mode.
* **Bug Fixes**
  * Standardized error messaging for save/sign-out actions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->